### PR TITLE
[sc-1234567] Add deployment workflows for Firebase and Cloudflare

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy Cloudflare Worker
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - uses: tinygo-org/setup-tinygo@v2
+        with:
+          tinygo-version: '0.33.0'
+      - run: npm ci
+      - run: make deploy
+        working-directory: worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -1,0 +1,19 @@
+name: Deploy Firebase Hosting
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx firebase deploy --only hosting
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy Firebase hosting on pushes to main
- add GitHub Actions workflow to deploy Cloudflare worker

## Testing
- `npm test` *(fails: Missing script: "test")*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68bed274d870832ba21a289f4facd92d