### PR TITLE
[sc-0000000] Fix Cloudflare deploy workflow

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -4,24 +4,38 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: worker-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
-  deploy:
+  deploy-worker:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
-      - uses: actions/setup-go@v5
+          cache-dependency-path: package-lock.json
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
           go-version: '1.22'
-      - uses: tinygo-org/setup-tinygo@v2
+      - name: Set up TinyGo
+        # Correct action (previously tinygo-org/setup-tinygo -> repo not found)
+        uses: acifani/setup-tinygo@v2
         with:
           tinygo-version: '0.33.0'
-      - run: npm ci
-      - run: make deploy
+      - name: Install wrangler deps
+        run: npm ci
+      - name: Deploy Worker
         working-directory: worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: make deploy


### PR DESCRIPTION
## Summary
- use maintained TinyGo action for Cloudflare worker deployment
- add concurrency and permissions to Cloudflare deploy workflow

## Testing
- `npm test` *(fails: Missing script "test")*
- `go test -v ./...` *(fails: directory prefix . does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b88dae10832b9af15872eb4b2800