### PR TITLE
[sc-000000] Preserve query parameters for custom icon handling

### DIFF
--- a/worker/internal/domain/server/app.go
+++ b/worker/internal/domain/server/app.go
@@ -88,10 +88,15 @@ func parseAppURL(u *url.URL) (*appURL, error) {
 		appURLValue = strings.TrimSuffix(appURLValue, suffix)
 	}
 
-	u, err := url.Parse("https://" + appURLValue)
+	base := "https://" + appURLValue
+	if u.RawQuery != "" {
+		base += "?" + u.RawQuery
+	}
+
+	parsedURL, err := url.Parse(base)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse app URL: %w", err)
 	}
 
-	return &appURL{URL: *u}, nil
+	return &appURL{URL: *parsedURL}, nil
 }

--- a/worker/internal/domain/server/app_test.go
+++ b/worker/internal/domain/server/app_test.go
@@ -27,6 +27,12 @@ func TestParseAppURL(t *testing.T) {
 			err:      nil,
 		},
 		{
+			name:     "URL with query",
+			input:    "https://example.com/a/google.com/some/path?foo=bar",
+			expected: &appURL{URL: url.URL{Scheme: "https", Host: "google.com", Path: "/some/path", RawQuery: "foo=bar"}},
+			err:      nil,
+		},
+		{
 			name:     "Invalid URL",
 			input:    "https://example.com/google.com",
 			expected: nil,

--- a/worker/internal/pkg/caching/links/cache.go
+++ b/worker/internal/pkg/caching/links/cache.go
@@ -83,5 +83,9 @@ func (c *cache) StoreIconURLs(u *url.URL, iconsURLs []*url.URL) error {
 }
 
 func keyFromURl(u *url.URL) string {
-	return u.Hostname() + strings.TrimSuffix(u.Path, "/")
+	key := u.Hostname() + strings.TrimSuffix(u.Path, "/")
+	if u.RawQuery != "" {
+		key += "?" + u.RawQuery
+	}
+	return key
 }

--- a/worker/internal/pkg/caching/links/cache_test.go
+++ b/worker/internal/pkg/caching/links/cache_test.go
@@ -1,0 +1,31 @@
+package links
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/nazar256/intopwa/internal/pkg/caching/links/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeyFromURLIncludesQuery(t *testing.T) {
+	u1, _ := url.Parse("https://example.com/path?foo=bar")
+	u2, _ := url.Parse("https://example.com/path?foo=baz")
+	assert.NotEqual(t, keyFromURl(u1), keyFromURl(u2))
+}
+
+func TestGetIconURLsUsesQueryInKey(t *testing.T) {
+	u, _ := url.Parse("https://example.com/path?foo=bar")
+	key := "example.com/path?foo=bar"
+
+	kv := mocks.NewKv(t)
+	kv.EXPECT().Get(key).Return([]byte(`["https://icon.com/favicon.ico"]`), nil).Once()
+
+	c := NewCache(kv)
+	urls, found, err := c.GetIconURLs(u)
+	assert.NoError(t, err)
+	assert.True(t, found)
+	if assert.Len(t, urls, 1) {
+		assert.Equal(t, "https://icon.com/favicon.ico", urls[0].String())
+	}
+}


### PR DESCRIPTION
## Summary
- preserve query string when parsing app URLs
- include query string in links cache keys
- cover app URL parsing and links cache query handling with tests

## Testing
- `cd worker && go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68bee5ee06c4832bab0e071c4a207cdb