### PR TITLE
[sc-1234] Preserve query params for manifest links

### DIFF
--- a/worker/internal/domain/server/urls.go
+++ b/worker/internal/domain/server/urls.go
@@ -21,13 +21,25 @@ func (u *appURL) appPath() string {
 }
 
 func (u *appURL) redirectPagePath() string {
-	return u.appPath() + redirectPagePath
+	path := u.appPath() + redirectPagePath
+	if u.RawQuery != "" {
+		path += "?" + u.RawQuery
+	}
+	return path
 }
 
 func (u *appURL) manifestPath() string {
-	return u.appPath() + manifestPath
+	path := u.appPath() + manifestPath
+	if u.RawQuery != "" {
+		path += "?" + u.RawQuery
+	}
+	return path
 }
 
 func (u *appURL) serviceWorkerPath() string {
-	return u.appPath() + serviceWorkerPath
+	path := u.appPath() + serviceWorkerPath
+	if u.RawQuery != "" {
+		path += "?" + u.RawQuery
+	}
+	return path
 }

--- a/worker/internal/domain/server/urls_test.go
+++ b/worker/internal/domain/server/urls_test.go
@@ -1,0 +1,15 @@
+package server
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net/url"
+	"testing"
+)
+
+func TestAppURLPathsIncludeQuery(t *testing.T) {
+	u := &appURL{URL: url.URL{Scheme: "https", Host: "www.windy.com", Path: "/test/meteogram", RawQuery: "49"}}
+
+	assert.Equal(t, "/a/www.windy.com/test/meteogram/manifest.json?49", u.manifestPath())
+	assert.Equal(t, "/a/www.windy.com/test/meteogram/service-worker.js?49", u.serviceWorkerPath())
+	assert.Equal(t, "/a/www.windy.com/test/meteogram/redirect.html?49", u.redirectPagePath())
+}


### PR DESCRIPTION
## Summary
- include query string when generating redirect, manifest, and service worker paths
- add test ensuring query parameters are preserved in generated paths

## Testing
- `cd worker && go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c6d4c03fa8832bb634f1e9215228ae