### PR TITLE
[sc-0000000] Skip Firebase deploy when auth secrets missing

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   deploy:
+    if: ${{ secrets.FIREBASE_TOKEN != '' || secrets.FIREBASE_SERVICE_ACCOUNT != '' || secrets.GCP_SA_KEY != '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,3 +18,9 @@ jobs:
       - run: npx firebase deploy --only hosting
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+  skip-deploy:
+    if: ${{ secrets.FIREBASE_TOKEN == '' && secrets.FIREBASE_SERVICE_ACCOUNT == '' && secrets.GCP_SA_KEY == '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip Firebase Hosting deploy
+        run: echo "Skipping Firebase Hosting deployment because no authentication secrets are configured."


### PR DESCRIPTION
## Summary
- skip Firebase Hosting deployment job when authentication inputs are not configured
- add an explicit log-only job to note when the deploy is skipped

## Testing
- not run (workflow configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68cb078f7c28832bb0f839f105e1cc8b