### PR TITLE
Support ports in generated app links

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -15,8 +15,11 @@ document.getElementById('createAppButton').addEventListener('click', function() 
             // Parse the URL
             var url = new URL(urlInput);
 
-            // Extract the domain and path
+            // Extract the domain, port, and path
             var domain = url.hostname; // domain (e.g., google.com)
+            if (url.port) {
+                domain += ':' + url.port;
+            }
             var path = url.pathname + url.search + url.hash; // path including query and hash
 
             // Construct the redirection URL

--- a/worker/internal/domain/server/app.go
+++ b/worker/internal/domain/server/app.go
@@ -88,6 +88,18 @@ func parseAppURL(u *url.URL) (*appURL, error) {
 		appURLValue = strings.TrimSuffix(appURLValue, suffix)
 	}
 
+	hostPart, remainder, hasRemainder := strings.Cut(appURLValue, "/")
+
+	decodedHost, err := url.PathUnescape(hostPart)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode app host: %w", err)
+	}
+
+	appURLValue = decodedHost
+	if hasRemainder {
+		appURLValue += "/" + remainder
+	}
+
 	base := "https://" + appURLValue
 	if u.RawQuery != "" {
 		base += "?" + u.RawQuery

--- a/worker/internal/domain/server/app_test.go
+++ b/worker/internal/domain/server/app_test.go
@@ -33,6 +33,18 @@ func TestParseAppURL(t *testing.T) {
 			err:      nil,
 		},
 		{
+			name:     "URL with port",
+			input:    "https://example.com/a/google.com:8080/some/path",
+			expected: &appURL{URL: url.URL{Scheme: "https", Host: "google.com:8080", Path: "/some/path"}},
+			err:      nil,
+		},
+		{
+			name:     "Encoded URL with port",
+			input:    "https://example.com/a/google.com%3A8080/some/path?foo=bar",
+			expected: &appURL{URL: url.URL{Scheme: "https", Host: "google.com:8080", Path: "/some/path", RawQuery: "foo=bar"}},
+			err:      nil,
+		},
+		{
 			name:     "Invalid URL",
 			input:    "https://example.com/google.com",
 			expected: nil,

--- a/worker/internal/domain/server/urls_test.go
+++ b/worker/internal/domain/server/urls_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 )
 
-func TestAppURLPathsIncludeQuery(t *testing.T) {
-	u := &appURL{URL: url.URL{Scheme: "https", Host: "www.windy.com", Path: "/test/meteogram", RawQuery: "49"}}
+func TestAppURLPathsIncludeQueryAndPort(t *testing.T) {
+	u := &appURL{URL: url.URL{Scheme: "https", Host: "www.windy.com:8443", Path: "/test/meteogram", RawQuery: "49"}}
 
-	assert.Equal(t, "/a/www.windy.com/test/meteogram/manifest.json?49", u.manifestPath())
-	assert.Equal(t, "/a/www.windy.com/test/meteogram/service-worker.js?49", u.serviceWorkerPath())
-	assert.Equal(t, "/a/www.windy.com/test/meteogram/redirect.html?49", u.redirectPagePath())
+	assert.Equal(t, "/a/www.windy.com:8443/test/meteogram/manifest.json?49", u.manifestPath())
+	assert.Equal(t, "/a/www.windy.com:8443/test/meteogram/service-worker.js?49", u.serviceWorkerPath())
+	assert.Equal(t, "/a/www.windy.com:8443/test/meteogram/redirect.html?49", u.redirectPagePath())
 }


### PR DESCRIPTION
## Summary
- include custom ports when building app requests from the UI
- decode percent-encoded hostnames before parsing app URLs so ports are preserved server-side
- extend server tests to cover hosts with explicit ports

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e4bb1aad3c832baf65631eb6d9bba4